### PR TITLE
perf: DB connection pooling and internal VPC routing

### DIFF
--- a/gcloud/deploy-services.sh
+++ b/gcloud/deploy-services.sh
@@ -42,7 +42,7 @@ echo ""
 DB_ZONE="${REGION}-a"
 DB_HOST=$(gcloud compute instances describe $DB_INSTANCE_NAME \
   --zone=$DB_ZONE --project=$PROJECT_ID \
-  --format='get(networkInterfaces[0].accessConfigs[0].natIP)' 2>/dev/null)
+  --format='get(networkInterfaces[0].networkIP)' 2>/dev/null)
 
 if [ -z "$DB_HOST" ]; then
   echo "❌ Could not get DB_HOST from Compute Engine instance $DB_INSTANCE_NAME"
@@ -63,6 +63,9 @@ gcloud run deploy multimodal-scout-backend \
   --set-env-vars DB_USER=scout_user \
   --set-env-vars DB_NAME=multimodal_scout \
   --set-env-vars DB_HOST=$DB_HOST \
+  --network default \
+  --subnet default \
+  --vpc-egress private-ranges-only \
   --cpu 1 \
   --memory 512Mi \
   --min-instances 0 \

--- a/gcloud/setup-db-instance.sh
+++ b/gcloud/setup-db-instance.sh
@@ -56,8 +56,8 @@ else
     --action=ALLOW \
     --rules=tcp:5432 \
     --target-tags=postgres-server \
-    --source-ranges=0.0.0.0/0 \
-    --description="Allow PostgreSQL access (secured by SSL + password auth)"
+    --source-ranges=10.0.0.0/8 \
+    --description="Allow PostgreSQL access from internal VPC only (Cloud Run Direct VPC egress)"
 fi
 
 # Wait for PostgreSQL to be ready

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -177,7 +177,13 @@ class DatabaseManager:
 
         self._is_test_environment = bool(os.getenv("PYTEST_CURRENT_TEST"))
 
-        self.engine = create_engine(database_url)
+        self.engine = create_engine(
+            database_url,
+            pool_size=5,
+            max_overflow=5,
+            pool_recycle=1800,
+            pool_pre_ping=True,
+        )
         self.SessionLocal = sessionmaker(
             autocommit=False, autoflush=False, bind=self.engine
         )


### PR DESCRIPTION
## Summary
- Add SQLAlchemy connection pooling (`pool_size=5, max_overflow=5`) to reuse DB connections instead of creating new TCP+SSL handshakes per query
- Enable Cloud Run Direct VPC egress to route DB traffic through Google's internal network (~1-5ms) instead of public internet (~20-50ms)
- Restrict PostgreSQL firewall from `0.0.0.0/0` to `10.0.0.0/8` (internal VPC only), closing the DB port to the public internet

## Test plan
- [ ] Update existing firewall rule: `gcloud compute firewall-rules update allow-postgres --source-ranges=10.0.0.0/8`
- [ ] Redeploy with `./gcloud/deploy-services.sh <project-id>`
- [ ] Verify backend can connect to DB (trigger a search or pipeline run)
- [ ] Monitor Cloud Run billing over 2-3 days to confirm cost reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)